### PR TITLE
various improvements

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,10 @@
+require 'json'
+
+BASE_PATH = File.expand_path(File.dirname(__FILE__))
+@files = JSON.parse(File.read(File.join(BASE_PATH, 'vendor.json')))
+
+task :default do
+  system("rake -T")
+end
+
 require "logstash/devutils/rake"

--- a/lib/logstash/filters/tld.rb
+++ b/lib/logstash/filters/tld.rb
@@ -1,8 +1,10 @@
 # encoding: utf-8
 require "logstash/filters/base"
 require "logstash/namespace"
+require 'resolv'
 
-# This example filter will replace the contents of the default 
+
+# This example filter will replace the contents of the default
 # message field with whatever you specify in the configuration.
 #
 # It is only intended to be used as an example.
@@ -19,36 +21,80 @@ class LogStash::Filters::Tld < LogStash::Filters::Base
   #
   config_name "tld"
   milestone 1
-  
+
   # The source field to parse
   config :source, :validate => :string, :default => "message"
 
   # The target field to place all the data
   config :target, :validate => :string, :default => "tld"
 
+  # should we parse consider special private domains as TLD
+  config :private_domains, :validate => :boolean, :default => true
+
+  # An array of domain fields to be included in the event.
+  # Possible fields are: "tld", "sld", "trd", "domain", "subdomain"
+  # defaults to domain subdomain
+  config :fields, :validate => :array, :default => %w(tld sld trd domain subdomain)
+
+  # Definition File
+  config :definition, :validate => :path
+
   public
   def register
-    # Add instance variables 
+    # Add instance variables
     require 'public_suffix'
+
+    if (@definition.nil?)
+        @definition = File.join(File.dirname(__FILE__), "..", "..", "..", "vendor", "public_suffix_list.dat")
+    end
+
+    if not File.exists?(@definition)
+        raise "You must specify 'definition => ...' in your domains filter (checked file '#{@definition}' which does not exist)"
+    end
+
+    PublicSuffix::List.default_definition=(File.new(@definition, "r:utf-8"))
+    PublicSuffix::List.private_domains=(@private_domains)
   end # def register
 
   public
   def filter(event)
 
-    if @source and PublicSuffix.valid?(event[@source])
-      domain = PublicSuffix.parse(event[@source])
-      # Replace the event message with our message as configured in the
-      # config file.
-      event[@target] = Hash.new
-      event[@target]['tld'] = domain.tld
-      event[@target]['sld'] = domain.sld
-      event[@target]['trd'] = domain.trd
-      event[@target]['domain'] = domain.domain
-      event[@target]['subdomain'] = domain.subdomain
+    if @source and event[@source]
+        input = event[@source]
 
-      # filter_matched should go in the last line of our successful code
-      filter_matched(event)
+        # check that the input is not an IP address
+        if input =~ Resolv::IPv4::Regex or input =~ Resolv::IPv6::Regex
+            return
+        end
 
+        if PublicSuffix.valid?(input)
+            begin
+                publicsuffix = PublicSuffix.parse(input)
+            rescue PublicSuffix::DomainNotAllowed
+                return
+            rescue PublicSuffix::DomainInvalid
+                return
+            end
+            domain = Hash.new
+            domain['tld'] = publicsuffix.tld
+            domain['sld'] = publicsuffix.sld
+            domain['trd'] = publicsuffix.trd
+            domain['domain'] = publicsuffix.domain
+            domain['subdomain'] = publicsuffix.subdomain
+
+            # Replace the event message with our message as configured in the
+            # config file, but only include the configured fields
+            event[@target] = Hash.new
+            domain.each do |key, value|
+                next if value.nil? or (value.is_a?(String) and value.empty?)
+                if @fields.nil? or @fields.empty? or @fields.include?(key.to_s)
+                    event[@target][key.to_s] = value
+                end
+            end
+
+            # filter_matched should go in the last line of our successful code
+            filter_matched(event)
+        end
     end
   end # def filter
 end # class LogStash::Filters::Example

--- a/logstash-filter-tld.gemspec
+++ b/logstash-filter-tld.gemspec
@@ -10,8 +10,9 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # Files
-  s.files = `git ls-files`.split($\)
-   # Tests
+  s.files = `git ls-files`.split($\)+::Dir.glob('vendor/*')
+
+  # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
 
   # Special flag to let us know this is actually a logstash plugin

--- a/spec/filters/tld_spec.rb
+++ b/spec/filters/tld_spec.rb
@@ -1,53 +1,121 @@
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/filters/tld"
+require 'public_suffix'
 
 describe LogStash::Filters::Tld do
-  describe "Set to TLD" do
-    config <<-CONFIG
-      filter {
-        tld {
+  context "with privte domains enabled" do
+
+      describe "Set to TLD" do
+        config <<-CONFIG
+          filter {
+            tld {
+            }
+          }
+        CONFIG
+
+        #{
+        #       "message" => "google.com",
+        #      "@version" => "1",
+        #    "@timestamp" => "2015-01-22T17:33:19.669Z",
+        #          "host" => "homer",
+        #      "sequence" => 0,
+        #           "tld" => {
+        #              "tld" => "com",
+        #              "sld" => "google",
+        #              "trd" => nil,
+        #           "domain" => "google.com",
+        #        "subdomain" => nil
+        #    }
+
+        sample("message" => "google.com") do
+          insist { subject["tld"]["tld"] } == "com"
+          insist { subject["tld"]["sld"] } == "google"
+          insist { subject["tld"]["trd"] } == nil
+          insist { subject["tld"]["domain"] } == "google.com"
+          insist { subject["tld"]["subdomain"] } == nil
+        end
+
+        sample("message" => "google.co.uk") do
+          insist { subject["tld"]["tld"] } == "co.uk"
+          insist { subject["tld"]["sld"] } == "google"
+          insist { subject["tld"]["trd"] } == nil
+          insist { subject["tld"]["domain"] } == "google.co.uk"
+          insist { subject["tld"]["subdomain"] } == nil
+        end
+
+        sample("message" => "www.google.com") do
+          insist { subject["tld"]["tld"] } == "com"
+          insist { subject["tld"]["sld"] } == "google"
+          insist { subject["tld"]["trd"] } == "www"
+          insist { subject["tld"]["domain"] } == "google.com"
+          insist { subject["tld"]["subdomain"] } == "www.google.com"
+        end
+        sample("message" => "foo.bar.appspot.com") do
+          insist { subject["tld"]["tld"] } == "appspot.com"
+          insist { subject["tld"]["sld"] } == "bar"
+          insist { subject["tld"]["trd"] } == "foo"
+          insist { subject["tld"]["domain"] } == "bar.appspot.com"
+          insist { subject["tld"]["subdomain"] } == "foo.bar.appspot.com"
+        end
+     end
+
+      describe "Include only specified fields" do
+        config <<-CONFIG
+          filter {
+            tld {
+               fields => [ tld , sld ]
+            }
+          }
+        CONFIG
+
+        sample("message" => "google.co.uk") do
+          insist { subject["tld"].length } == 2
+          insist { subject["tld"]["tld"] } == "co.uk"
+          insist { subject["tld"]["sld"] } == "google"
+        end
+      end
+  end
+  context "with privte domains disabled" do
+      config <<-CONFIG
+        filter {
+          tld {
+             private_domains => false
+          }
         }
-      }
-    CONFIG
+      CONFIG
 
-#{
-#       "message" => "google.com",
-#      "@version" => "1",
-#    "@timestamp" => "2015-01-22T17:33:19.669Z",
-#          "host" => "homer",
-#      "sequence" => 0,
-#           "tld" => {
-#              "tld" => "com",
-#              "sld" => "google",
-#              "trd" => nil,
-#           "domain" => "google.com",
-#        "subdomain" => nil
-#    }
+      describe "Disable private domain parsing" do
+        sample("message" => "google.com") do
+          insist { subject["tld"]["tld"] } == "com"
+          insist { subject["tld"]["sld"] } == "google"
+          insist { subject["tld"]["trd"] } == nil
+          insist { subject["tld"]["domain"] } == "google.com"
+          insist { subject["tld"]["subdomain"] } == nil
+        end
 
+        sample("message" => "google.co.uk") do
+          insist { subject["tld"]["tld"] } == "co.uk"
+          insist { subject["tld"]["sld"] } == "google"
+          insist { subject["tld"]["trd"] } == nil
+          insist { subject["tld"]["domain"] } == "google.co.uk"
+          insist { subject["tld"]["subdomain"] } == nil
+        end
 
-    sample("message" => "google.com") do
-      insist { subject["tld"]["tld"] } == "com"
-      insist { subject["tld"]["sld"] } == "google"
-      insist { subject["tld"]["trd"] } == nil
-      insist { subject["tld"]["domain"] } == "google.com"
-      insist { subject["tld"]["subdomain"] } == nil
-    end
+        sample("message" => "www.google.com") do
+          insist { subject["tld"]["tld"] } == "com"
+          insist { subject["tld"]["sld"] } == "google"
+          insist { subject["tld"]["trd"] } == "www"
+          insist { subject["tld"]["domain"] } == "google.com"
+          insist { subject["tld"]["subdomain"] } == "www.google.com"
+        end
 
-    sample("message" => "google.co.uk") do
-      insist { subject["tld"]["tld"] } == "co.uk"
-      insist { subject["tld"]["sld"] } == "google"
-      insist { subject["tld"]["trd"] } == nil
-      insist { subject["tld"]["domain"] } == "google.co.uk"
-      insist { subject["tld"]["subdomain"] } == nil
-    end
-
-    sample("message" => "www.google.com") do
-      insist { subject["tld"]["tld"] } == "com"
-      insist { subject["tld"]["sld"] } == "google"
-      insist { subject["tld"]["trd"] } == "www"
-      insist { subject["tld"]["domain"] } == "google.com"
-      insist { subject["tld"]["subdomain"] } == "www.google.com"
-    end
-
+        sample("message" => "foo.bar.appspot.com") do
+          insist { subject["tld"]["tld"] } == "com"
+          insist { subject["tld"]["sld"] } == "appspot"
+          insist { subject["tld"]["trd"] } == "foo.bar"
+          insist { subject["tld"]["domain"] } == "appspot.com"
+          insist { subject["tld"]["subdomain"] } == "foo.bar.appspot.com"
+        end
+      end
   end
 end

--- a/vendor.json
+++ b/vendor.json
@@ -1,0 +1,4 @@
+[{
+        "sha1": "5ab0d8794859b3fce1121e94c05adc63c29e06ff",
+        "url": "https://raw.githubusercontent.com/publicsuffix/list/ee621394b6d863dcc2ff89956d91cdd7d15d8c9d/public_suffix_list.dat"
+}]


### PR DESCRIPTION
* include most recent publicsuffix list (as gem version is already outdated and no new version is compatible with jruby)
* allow to specify own public suffix definition list via configuration (definition => /path/to/publicsuffix.dat)
* allow to disable private_domains parsing ( don't parse foo.bar.appspot.com to tld appspot.com)
* allows to specify which fields are added (per default all fields are included, but can be arbitrarily restricted)