### PR TITLE
Update tld.rb

### DIFF
--- a/lib/logstash/filters/tld.rb
+++ b/lib/logstash/filters/tld.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "logstash/filters/base"
 require "logstash/namespace"
+require 'uri'
 
 # This example filter will replace the contents of the default 
 # message field with whatever you specify in the configuration.
@@ -26,29 +27,67 @@ class LogStash::Filters::Tld < LogStash::Filters::Base
   # The target field to place all the data
   config :target, :validate => :string, :default => "tld"
 
+  # private domains
+  config :private_domains, :validate => :string, :default => false
+
   public
   def register
     # Add instance variables 
     require 'public_suffix'
+
   end # def register
 
   public
   def filter(event)
 
-    if @source and PublicSuffix.valid?(event[@source])
-      domain = PublicSuffix.parse(event[@source])
-      # Replace the event message with our message as configured in the
-      # config file.
-      event[@target] = Hash.new
-      event[@target]['tld'] = domain.tld
-      event[@target]['sld'] = domain.sld
-      event[@target]['trd'] = domain.trd
-      event[@target]['domain'] = domain.domain
-      event[@target]['subdomain'] = domain.subdomain
+    # take the first element in the array, if array is passed
 
-      # filter_matched should go in the last line of our successful code
-      filter_matched(event)
+    source_string = event[@source]
+    source_string = source_string.first if source_string.is_a?(Array)
 
+    return if source_string.nil? || source_string.empty?
+
+    # private domain config -- default is false which is ideal for most
+
+    PublicSuffix::List.private_domains = @private_domains
+
+    domain = source_string.strip
+
+    # test to see if it's a URL
+    begin
+      uri = URI(source_string)
+      if uri.host
+        domain = uri.host
+        @logger.info("a url was passed in")
+      end
+    rescue
+      @logger.info("not a url")
     end
+
+    # hostname now ready for parsing
+    begin
+      domain = PublicSuffix.parse(domain)
+      event[@target] = Hash.new
+      if domain.tld
+        event[@target]['tld'] = domain.tld 
+      end
+      if domain.sld
+        event[@target]['sld'] = domain.sld
+      end
+      if domain.trd
+        event[@target]['trd'] = domain.trd
+      end
+      if domain.domain
+        event[@target]['domain'] = domain.domain
+      end
+      if domain.subdomain
+        event[@target]['subdomain'] = domain.subdomain
+      end
+      filter_matched(event)
+    rescue
+      @logger.info("invalid domain")
+    end
+
+
   end # def filter
 end # class LogStash::Filters::Example


### PR DESCRIPTION
made it so you can pass in a URL or a domain for parsing.  URL is stripped using ruby's URI found in the standard library.  I also don't verify PublicSuffix which cuts down on processing.  Instead, I use a begin/rescue which i believe is less expensive,

documentation would have to be updated too - haven't submitted a pull request for that until the code gets cleaned up and approved