### PR TITLE
Do not overwrite existing object and new subdomain handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.2.0
   - Do not overwrite existing object in event (e.g. make it possible to read from [source][nmae] and write to [source])
+  - separate hostname from subdomain if present
 
 ## 3.1.1
   - Honor ECS and add top_level_domain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.0
+  - Do not overwrite existing object in event (e.g. make it possible to read from [source][nmae] and write to [source])
+
 ## 3.1.1
   - Honor ECS and add top_level_domain
 

--- a/lib/logstash/filters/tld.rb
+++ b/lib/logstash/filters/tld.rb
@@ -38,7 +38,8 @@ class LogStash::Filters::Tld < LogStash::Filters::Base
       domain = PublicSuffix.parse(event.get(@source))
       # Replace the event message with our message as configured in the
       # config file.
-      h = Hash.new
+      h = event.get(@target) 
+      h = Hash.new if h.nil?
       h['tld'] = domain.tld
       h['sld'] = domain.sld
       h['trd'] = domain.trd

--- a/logstash-filter-tld.gemspec
+++ b/logstash-filter-tld.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-tld'
-  s.version         = '3.1.1'
+  s.version         = '3.2.0'
   s.licenses = ['Apache-2.0']
   s.summary = "Replaces the contents of the default message field with whatever you specify in the configuration"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/tld_spec.rb
+++ b/spec/filters/tld_spec.rb
@@ -53,5 +53,14 @@ describe LogStash::Filters::Tld do
       insist { subject.get("tld")["subdomain"] } == "www.google.com"
     end
 
+    sample("message" => "host.subdomain.example.com") do
+      insist { subject.get("tld")["tld"] } == "com"
+      insist { subject.get("tld")["top_level_domain"] } == "com"
+      insist { subject.get("tld")["sld"] } == "example"
+      insist { subject.get("tld")["trd"] } == "host.subdomain"
+      insist { subject.get("tld")["domain"] } == "example.com"
+      insist { subject.get("tld")["subdomain"] } == "subdomain.example.com"
+    end
+
   end
 end


### PR DESCRIPTION
Hi

Those changes make it much easier for us to move to ECS.

1. Do not overwrite an existing object, enables to use the following code:
`tld {
                source => "[source][name]"
                target => "[source]"
            }`

2. The new subdomain code separates the hostname from the subdomain.

Have fun
Patrick