### PR TITLE
Do not overwrite existing object in event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.0
+  - Do not overwrite existing object in event (e.g. make it possible to read from [source][nmae] and write to [source])
+
 ## 3.1.1
   - Honor ECS and add top_level_domain
 

--- a/lib/logstash/filters/tld.rb
+++ b/lib/logstash/filters/tld.rb
@@ -38,7 +38,8 @@ class LogStash::Filters::Tld < LogStash::Filters::Base
       domain = PublicSuffix.parse(event.get(@source))
       # Replace the event message with our message as configured in the
       # config file.
-      h = Hash.new
+      h = event.get(@target) 
+      h = Hash.new if h.nil?
       h['tld'] = domain.tld
       h['sld'] = domain.sld
       h['trd'] = domain.trd

--- a/logstash-filter-tld.gemspec
+++ b/logstash-filter-tld.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-tld'
-  s.version         = '3.1.1'
+  s.version         = '3.2.0'
   s.licenses = ['Apache-2.0']
   s.summary = "Replaces the contents of the default message field with whatever you specify in the configuration"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Hi

I would like to propose the following change since it makes it much easier to implement ECS.

Do not overwrite an existing object, enables to use the following code:
tld { source => "[source][name]" target => "[source]" }


Have fun
Patrick