### PR TITLE
Bump public_suffix and updated specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.1.3
-  - Bumped `public_suffix` gem version to 4 and updated specs [#24](https://github.com/logstash-plugins/logstash-filter-tld/issues/24)
+  - Bumped `public_suffix` gem version to `> 3` `< 6` and updated specs [#24](https://github.com/logstash-plugins/logstash-filter-tld/issues/24)
 
 ## 3.1.2
   - Fix race condition initializing PublicSuffix list [#8](https://github.com/logstash-plugins/logstash-filter-tld/issues/8)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.1.3
-  - Bumped `public_suffix` gem version to 4 and updated specs [#19](https://github.com/logstash-plugins/logstash-filter-tld/issues/19)
+  - Bumped `public_suffix` gem version to 4 and updated specs [#24](https://github.com/logstash-plugins/logstash-filter-tld/issues/24)
 
 ## 3.1.2
   - Fix race condition initializing PublicSuffix list [#8](https://github.com/logstash-plugins/logstash-filter-tld/issues/8)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.1.3
-  - Bumped `public_suffix` gem version to `> 3` `< 6` and updated specs [#24](https://github.com/logstash-plugins/logstash-filter-tld/issues/24)
+  - Bumped `public_suffix` gem version to `> 4` `< 6` and updated specs [#24](https://github.com/logstash-plugins/logstash-filter-tld/issues/24)
 
 ## 3.1.2
   - Fix race condition initializing PublicSuffix list [#8](https://github.com/logstash-plugins/logstash-filter-tld/issues/8)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.3
+  - Bumped `public_suffix` gem version to 4 and updated specs [#19](https://github.com/logstash-plugins/logstash-filter-tld/issues/19)
+
 ## 3.1.2
   - Fix race condition initializing PublicSuffix list [#8](https://github.com/logstash-plugins/logstash-filter-tld/issues/8)
 

--- a/logstash-filter-tld.gemspec
+++ b/logstash-filter-tld.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-tld'
-  s.version         = '3.1.2'
+  s.version         = '3.1.3'
   s.licenses = ['Apache-2.0']
   s.summary = "Replaces the contents of the default message field with whatever you specify in the configuration"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -17,14 +17,12 @@ Gem::Specification.new do |s|
   # Special flag to let us know this is actually a logstash plugin
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "filter" }
 
-  # public_suffix 3.x+ includes ruby syntax from 2.1
-  # This effectively requires Logstash >= 6.x
-  s.required_ruby_version = '>= 2.1.0'
+  # public_suffix 5.x+ includes ruby syntax from 2.6
+  s.required_ruby_version = '>= 2.3'
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency 'public_suffix', '~>3'
+  s.add_runtime_dependency 'public_suffix', '~> 4'
 
   s.add_development_dependency 'logstash-devutils'
-  s.add_development_dependency 'insist'
 end

--- a/logstash-filter-tld.gemspec
+++ b/logstash-filter-tld.gemspec
@@ -17,12 +17,14 @@ Gem::Specification.new do |s|
   # Special flag to let us know this is actually a logstash plugin
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "filter" }
 
+  # Logstash 7.17.x-8.x uses ruby 2.5-3.1 compatiblity
+  # public_suffix 4.x+ includes ruby syntax from 2.3
   # public_suffix 5.x+ includes ruby syntax from 2.6
   s.required_ruby_version = '>= 2.3'
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency 'public_suffix', '~> 4'
+  s.add_runtime_dependency 'public_suffix', '> 3', '< 6'
 
   s.add_development_dependency 'logstash-devutils'
 end

--- a/logstash-filter-tld.gemspec
+++ b/logstash-filter-tld.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency 'public_suffix', '> 3', '< 6'
+  s.add_runtime_dependency 'public_suffix', '> 4', '< 6'
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
- Bumped `public_suffix ` to version 4 as version 5 requires Ruby 2.6
- Migrated specs to `rspec` format as removed incompatible`insist` gem 

---
Closes: https://github.com/logstash-plugins/logstash-filter-tld/issues/23
